### PR TITLE
add twitter (and X) to plugin description

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
   "title": "Tweet archive",
-  "description": "Companion plug-in to Micro.blog's tweets import feature.",
+  "description": "Companion plug-in to Micro.blog's Twitter (X) import feature.",
   "version": "1.0.3"
 }


### PR DESCRIPTION
I was looking for this plugin and couldn't find it when I searched for "Twitter", when I should have searched for "tweet". With this edit both "Twitter", "tweet" and "X" works if you support one character searches.